### PR TITLE
case insensitive search

### DIFF
--- a/src/partition.c
+++ b/src/partition.c
@@ -126,7 +126,7 @@ int search_partition_in_dir(const char *dir_path, const char *target) {
     }
     
     while ((entry = readdir(dp)) != NULL) {
-        if (strncmp(entry->d_name, target, strlen(target)) == 0) {
+        if (strncasecmp(entry->d_name, target, strlen(target)) == 0) {
             closedir(dp);
             return 1;
         }


### PR DESCRIPTION
This PR replaces `strncmp` with `strncasecmp` in `search_partition_in_dir()` to allow case-insensitive matching of partition names during auto-discovery (locating "BOOT" vs "boot")

Another fix could be `sed -i 's/strncmp/strncasecmp/g' src/partition.c` in `build.sh`
